### PR TITLE
appendChild type changed.

### DIFF
--- a/goodnight.js
+++ b/goodnight.js
@@ -19,7 +19,7 @@
 			ln.push(item);
 
 			if (this.night()) {
-				document.head.appendChild(item);
+				document.documentElement.firstChild.appendChild(item);
 			}
 		};
 
@@ -28,7 +28,7 @@
 				if (ln[i].parentNode) {
 					ln[i].parentNode.removeChild(ln[i]);
 				} else {
-					document.head.appendChild(ln[i]);
+					document.documentElement.firstChild.appendChild(ln[i]);
 				}
 			}
 		};


### PR DESCRIPTION
Sometimes head element could be missing. In that case that script could break out. Now it just searches the first element and than appends it-self.

More: http://www.stevesouders.com/blog/2010/05/11/appendchild-vs-insertbefore/
